### PR TITLE
feat: Update GitVersion.yml to Mainline mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -387,6 +387,6 @@ FodyWeavers.xsd
 .idea/
 *.sln.iml
 /output
-/.nuke/temp/release_notes.md
+/.nuke/temp/
 /build/Properties/launchSettings.json
 /templates/ZtrTemplates.Console/Properties/launchSettings.json

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,44 +1,23 @@
-workflow: GitFlow/v1 # Temporarily commented out to let GitVersion infer from branches
-
+mode: Mainline
 branches:
-  master:
+  main:
     regex: ^(master|main)$
-    label: ''
     increment: Patch
-    track-merge-target: false
-    is-release-branch: true
-
+    prevent-increment-of-merged-branch-version: true
+    tag: ''
   develop:
     regex: ^develop$
-    label: alpha
     increment: Minor
-    track-merge-target: true
-    is-release-branch: false
-
+    prevent-increment-of-merged-branch-version: true
+    tag: alpha
+    source-branches: [main]
   feature:
-    # This regex will match any branch name that is NOT 'master' or 'develop'.
-    # It also implicitly won't match 'release/...' or 'hotfix/...' if you add those
-    # configurations later, because those more specific regexes would match first.
-    regex: ^(?!(master|develop|release|hotfix)$)(?<BranchName>.+)$
-    label: '{BranchName}'
+    regex: ^features?[/-]
     increment: Inherit
-    source-branches: [develop, main, master]
-    track-merge-target: false
-    is-release-branch: false
-
+    tag: '{BranchName}'
+    source-branches: [develop]
   hotfix:
-    regex: hotfixes?[/-]
-    label: beta
+    regex: ^hotfix(es)?[/-]
     increment: Patch
-    source-branches: [master, main]
-    track-merge-target: false
-    is-release-branch: true
-
-# Optional: Release branches (if you use them as part of GitFlow)
-#  release:
-#    regex: releases?[/-]
-#    label: rc # Release Candidate (e.g., 1.0.0-rc.1)
-#    increment: None # Version is usually set when branching from develop
-#    prevent-increment-of-merged-branch-version: true
-#    track-merge-target: false
-#    is-release-branch: true
+    tag: hotfix
+    source-branches: [main]


### PR DESCRIPTION
Updates the GitVersion.yml configuration to use Mainline mode, which simplifies the versioning strategy and aligns with the desired workflow.

The new configuration ensures that:
- Merges from `develop` to `main` increment the minor version.
- Merges from `hotfix` to `main` increment the patch version.
- Builds on `develop` have an `-alpha` suffix.
- Builds on `hotfix` have a `-hotfix` suffix.
- Major versions are bumped by creating a tag.

Also updates .gitignore to ignore the entire .nuke/temp directory.