### PR TITLE
docs: Dodaj sekcję Getting Started i uprość Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,14 +2,6 @@
   <img src="templates/ZtrTemplates.Console/applogo.png" width="200" alt="ZTR Templates Logo">
 </p>
 
-![NuGet Version and Downloads count](https://buildstats.info/nuget/ZTR.Utilities.Templates)
-========
-
-Download
-========
-
-The newest package is available [on NuGet](https://buildstats.info/nuget/ZTR.Utilities.Templates).
-
 Generowanie kluczy SSH
 ========
 
@@ -30,46 +22,9 @@ Tutaj prezentuję listę szablonów, które również warto rozważyć przy zacz
 
 - <https://github.com/dotnet/templating/wiki/Available-templates-for-dotnet-new> - lista różnych projektów z szablonami
 
-Dokumentacja (Docusaurus)
-========
+# After cloning this repo
 
-Projekt zawiera wbudowaną dokumentację opartą na [Docusaurus](https://docusaurus.io/). Znajduje się ona w folderze `docs/`.
-
-**Live Documentation:** [🚀 View Docs](https://mikdal002.github.io/ZTR.Templates/)
-
-### Lokalne uruchomienie
-
-1. Przejdź do folderu: `cd docs`
-2. Zainstaluj zależności: `npm install`
-3. Uruchom serwer: `npm start` (zmiany powinny odświeżać się automatycznie)
-4. Zacznij pisać dokumentacje
-
-### Automatyzacja (GitHub Actions)
-
-Workflow `.github/workflows/publish_docs.yml` automatycznie:
-
-- Buduje dokumentację przy każdym `push` do `main`.
-- Wdraża podgląd (PR Preview) dla każdego Pull Requesta.
-- Publikuje gotową stronę na GitHub Pages.
-
-Post-Clone Checklist
-========
-
-Po użyciu tego szablonu do stworzenia nowego projektu, wykonaj poniższe kroki, aby w pełni skonfigurować infrastrukturę:
-
-- [ ] **GitHub Pages**: Wejdź w `Settings -> Pages`. W sekcji `Build and deployment -> Source` wybierz **"Deploy from a branch"**. Jako branch wybierz `gh-pages` (pojawi się po pierwszym uruchomieniu workflow) i folder `/(root)`.
-- [ ] **Docusaurus Config**: Zaktualizuj plik `docs/docusaurus.config.ts`. Zmień `url`, `organizationName` oraz `projectName` na dane Twojego nowego repozytorium.
-- [ ] **Secrets**: Jeśli planujesz używać wdrożeń SSH (Velopack), dodaj odpowiednie sekrety (`SSH_HOST`, `SSH_USER`, `SSH_KEY`) w ustawieniach repozytorium.
-
-## Konfiguracja repozytorium GitHub po sklonowaniu
-
-Aby walidacja tytułów PR poprawnie przekładała się na historię commita na głównej gałęzi, należy odpowiednio skonfigurować repozytorium w ustawieniach GitHub (**Settings -> General -> Pull Requests**):
-
-1. **Włącz opcję "Allow squash merging"**.
-2. W sekcji **"Default commit message"** dla squash merge'y wybierz opcję **"Pull request title"**.
-
-Jest to niezbędne, ponieważ GitHub nie pozwala na konfigurację tych ustawień za pomocą kodu ("as-a-code"). Dzięki temu zwalidowany tytuł Pull Requesta automatycznie stanie się komunikatem commita podczas łączenia zmian.
-
+All steps that should be performed after cloning this repository are described in `./docs/docs/getting-started/*`. These instructions are also available at [🚀 Getting Started](https://mikdal002.github.io/ZTR.Templates/getting-started/intro).
 
 ## Branching Strategy and Versioning
 
@@ -77,39 +32,39 @@ This project uses a GitFlow-inspired branching model, automated with GitVersion.
 
 **Main Branches:**
 
-* **`master`**:-   **`master`**:
-    * Represents the production-ready state of the project.    -   Represents the production-ready state of the project.
-    * Commits are typically merges from `develop` (for releases) or `hotfix` branches.    -   Commits are typically merges from `develop` (for releases) or `hotfix` branches.
-    * **Versioning (GitVersion):**    -   **Versioning (GitVersion):**
-        * Format: `Major.Minor.Patch` (e.g., `1.0.0`, `1.1.0`, `1.1.1`).        -   Format: `Major.Minor.Patch` (e.g., `1.0.0`, `1.1.0`, `1.1.1`).
-        * `increment: Patch` (though the version is usually determined by the branch being merged).        -   `increment: Patch` (though the version is usually determined by the branch being merged).
-        * `tag: ''` (no pre-release tag).        -   `tag: ''` (no pre-release tag).
+- **`master`**:
+    - Represents the production-ready state of the project.
+    - Commits are typically merges from `develop` (for releases) or `hotfix` branches.
+    - **Versioning (GitVersion):**
+        - Format: `Major.Minor.Patch` (e.g., `1.0.0`, `1.1.0`, `1.1.1`).
+        - `increment: Patch` (though the version is usually determined by the branch being merged).
+        - `tag: ''` (no pre-release tag).
 
-* **`develop`**:-   **`develop`**:
-    * Serves as the main integration branch for new features. All feature branches are merged into `develop`.    -   Serves as the main integration branch for new features. All feature branches are merged into `develop`.
-    * When `develop` is stable and ready for a release, it's merged into `master`.    -   When `develop` is stable and ready for a release, it's merged into `master`.
-    * **Versioning (GitVersion):**    -   **Versioning (GitVersion):**
-        * Format: `Major.Minor.Patch-alpha.Commits` (e.g., `1.1.0-alpha.1`, `1.2.0-alpha.5`).        -   Format: `Major.Minor.Patch-alpha.Commits` (e.g., `1.1.0-alpha.1`, `1.2.0-alpha.5`).
-        * `increment: Minor` (advances the minor version based on `master` due to `track-merge-target: true`).        -   `increment: Minor` (advances the minor version based on `master` due to `track-merge-target: true`).
-        * `tag: alpha`.        -   `tag: alpha`.
+- **`develop`**:
+    - Serves as the main integration branch for new features. All feature branches are merged into `develop`.
+    - When `develop` is stable and ready for a release, it's merged into `master`.
+    - **Versioning (GitVersion):**
+        - Format: `Major.Minor.Patch-alpha.Commits` (e.g., `1.1.0-alpha.1`, `1.2.0-alpha.5`).
+        - `increment: Minor` (advances the minor version based on `master` due to `track-merge-target: true`).
+        - `tag: alpha`.
 
 **Supporting Branches:**
 
-* **`feature/*`** (e.g., `feature/new-user-auth`):-   **`feature/*`** (e.g., `feature/new-user-auth`):
-    * Typically branched from `develop` for new development work, but can also originate from `main` or `master` if needed.    -   Typically branched from `develop` for new development work, but can also originate from `main` or `master` if needed.
-    * Merged back into `develop` upon completion.    -   Merged back into `develop` upon completion.
-    * **Versioning (GitVersion):**    -   **Versioning (GitVersion):**
-        * Format: `InheritedBaseVersion-BranchName.Commits` (e.g., `1.1.0-new-user-auth.3` if branched from `develop` at `1.1.0-alpha.x`).        -   Format: `InheritedBaseVersion-BranchName.Commits` (e.g., `1.1.0-new-user-auth.3` if branched from `develop` at `1.1.0-alpha.x`).
-        * `increment: Inherit`.        -   `increment: Inherit`.
-        * `tag: use-branch-name`.        -   `tag: use-branch-name`.
+- **`feature/*`** (e.g., `feature/new-user-auth`):
+    - Typically branched from `develop` for new development work, but can also originate from `main` or `master` if needed.
+    - Merged back into `develop` upon completion.
+    - **Versioning (GitVersion):**
+        - Format: `InheritedBaseVersion-BranchName.Commits` (e.g., `1.1.0-new-user-auth.3` if branched from `develop` at `1.1.0-alpha.x`).
+        - `increment: Inherit`.
+        - `tag: use-branch-name`.
 
-* **`hotfix/*`** (e.g., `hotfix/critical-security-patch`):-   **`hotfix/*`** (e.g., `hotfix/critical-security-patch`):
-    * Branched from `master` to address urgent production issues.    -   Branched from `master` to address urgent production issues.
-    * Merged back into both `master` (to release the fix) and `develop` (to ensure the fix is in future development).    -   Merged back into both `master` (to release the fix) and `develop` (to ensure the fix is in future development).
-    * **Versioning (GitVersion):**    -   **Versioning (GitVersion):**
-        * Format: `MasterBaseVersion.PatchIncrement-beta.Commits` (e.g., `1.1.1-beta.1` if `master` was `1.1.0`).        -   Format: `MasterBaseVersion.PatchIncrement-beta.Commits` (e.g., `1.1.1-beta.1` if `master` was `1.1.0`).
-        * `increment: Patch`.        -   `increment: Patch`.
-        * `tag: beta`.        -   `tag: beta`.
+- **`hotfix/*`** (e.g., `hotfix/critical-security-patch`):
+    - Branched from `master` to address urgent production issues.
+    - Merged back into both `master` (to release the fix) and `develop` (to ensure the fix is in future development).
+    - **Versioning (GitVersion):**
+        - Format: `MasterBaseVersion.PatchIncrement-beta.Commits` (e.g., `1.1.1-beta.1` if `master` was `1.1.0`).
+        - `increment: Patch`.
+        - `tag: beta`.
 
 **Workflow Diagram:**
 

--- a/docs/docs/getting-started/_category_.json
+++ b/docs/docs/getting-started/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Initial setup and configuration of ZTR.Template",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "description": "What to do after cloning the repository."
+  }
+}

--- a/docs/docs/getting-started/documentation.mdx
+++ b/docs/docs/getting-started/documentation.mdx
@@ -1,0 +1,32 @@
+---
+sidebar_position: 2
+---
+
+# Live Documentation (Docusaurus)
+
+The project includes built-in documentation based on [Docusaurus](https://docusaurus.io/). It is located in the `docs/` folder.
+
+**Live Documentation:** [🚀 View Docs](https://mikdal002.github.io/ZTR.Templates/)
+
+## Running Locally
+
+1. Go to the folder: `cd docs`
+2. Install dependencies: `npm install`
+3. Start the server: `npm start` (changes should refresh automatically)
+4. Start adding content
+
+## Automation (GitHub Actions)
+
+The `.github/workflows/publish_docs.yml` workflow automatically:
+
+- Builds the documentation on every `push` to `main`.
+- Deploys a PR Preview for every Pull Request.
+- Publishes the ready site to GitHub Pages.
+
+## Post-Clone Checklist
+
+After using this template to create a new project, follow these steps to fully configure the infrastructure:
+
+- [ ] **GitHub Pages**: Go to `Settings -> Pages`. In the `Build and deployment -> Source` section, select **"Deploy from a branch"**. Choose the `gh-pages` branch (it will appear after the first workflow run) and the `/(root)` folder.
+- [ ] **Docusaurus Config**: Update the `docs/docusaurus.config.ts` file. Change `url`, `organizationName`, and `projectName` to your new repository details.
+- [ ] **Secrets**: If you plan to use SSH deployments (Velopack), add the appropriate secrets (`SSH_HOST`, `SSH_USER`, `SSH_KEY`) in the repository settings.

--- a/docs/docs/getting-started/general-repository-setup.mdx
+++ b/docs/docs/getting-started/general-repository-setup.mdx
@@ -1,0 +1,16 @@
+---
+sidebar_position: 1
+---
+
+# General Repository Setup
+
+## PR Title Validation
+
+To ensure that Pull Request title validation correctly translates to the commit history on the main branch, the repository must be properly configured in the GitHub settings (**Settings -> General -> Pull Requests**):
+
+1. **Enable the "Allow squash merging" option**.
+2. In the **"Default commit message"** section for squash merges, select the **"Pull request title"** option.
+
+This is necessary because GitHub does not allow configuring these settings "as code". 
+As a result, the validated Pull Request title will automatically become the commit message when merging changes. 
+This is important because the repository includes automatic changelog generation based on commits.

--- a/docs/docs/getting-started/husky-net.mdx
+++ b/docs/docs/getting-started/husky-net.mdx
@@ -1,0 +1,11 @@
+
+# Husky.Net
+
+Husky.Net is used to manage Git hooks. 
+It currently handles pre-commit hooks for 'dotnet format'.
+Configuration can be found in the `.husky/pre-commit` and `task-runner.json` files.
+
+## Installation
+
+The installation process is uniquely integrated via the `Directory.Build.targets` file.
+This has its disadvantages (such as a possible deadlock during the first setup), but also has the advantage that the installation is done automatically during the first build, so there is no need to do it manually.

--- a/docs/docs/getting-started/intro.mdx
+++ b/docs/docs/getting-started/intro.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 0
+---
+
+# Getting Started with the Template
+
+This section covers the features provided by this template and includes the necessary setup instructions for after cloning the repository.
+
+You will find here:
+- [General Repository Setup](./general-repository-setup.mdx) - GitHub repository configuration for the best experience.
+- [Documentation](./documentation.mdx) - How to use the built-in documentation based on Docusaurus.
+- [Husky.Net](./husky-net.mdx) - A short description of Husky.Net usage and how to add your own hooks.

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -6,8 +6,12 @@ sidebar_position: 1
 
 This page should contain information about the project you are currently in.
 
+Go to [Getting Started](./getting-started/intro.mdx) to see the checklist of things to do after cloning the repository.
+
 The other pages in the "Tutorial - *" categories demonstrate how to use this engine to create documentation.
 They have been kept here for reference.
+
+
 
 ## Running the Site
 

--- a/docs/docs/tutorial-basics/_category_.json
+++ b/docs/docs/tutorial-basics/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Tutorial - Basics",
-  "position": 2,
+  "position": 3,
   "link": {
     "type": "generated-index",
     "description": "5 minutes to learn the most important Docusaurus concepts."

--- a/docs/docs/tutorial-extras/_category_.json
+++ b/docs/docs/tutorial-extras/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Tutorial - Extras",
-  "position": 3,
+  "position": 4,
   "link": {
     "type": "generated-index"
   }


### PR DESCRIPTION
Zaktualizowano Readme.md – szczegółowe instrukcje powykonawcze oraz dokumentację przeniesiono do nowej sekcji Getting Started w dokumentacji. Dodano pliki: intro.mdx (wprowadzenie), general-repository-setup.mdx (konfiguracja repozytorium), documentation.mdx (obsługa dokumentacji Docusaurus), husky-net.mdx (opis Husky.Net). Dodano plik _category_.json dla Getting Started i zmieniono pozycje sidebarów, aby uwzględnić nową sekcję. Dodano odnośnik do Getting Started w głównej stronie intro.mdx.